### PR TITLE
Now a drop-in replacement for Rack::Deflater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language:
+  - ruby
+rvm:
+  - 2.0.0
+  - 2.1.5
+  - 2.2.0
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install libjack0 libjack-dev
+  - sudo apt-get install libportaudiocpp0 portaudio19-dev libmpg123-dev
+branches:
+  only:
+    - master
+cache:
+  - bundler
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Or install it yourself as:
 
 ## Usage
 
-`Rack::Deflatermaus` is a standard Rack middleware.
+`Rack::Deflatermaus` is a drop-in replacement for [`Rack::Deflater`]. You can
+use it anywhere you'd use `Rack::Deflater`.
+
+[`Rack::Deflater`]: http://robots.thoughtbot.com/content-compression-with-rack-deflater
 
 In Rails:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,7 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new
+
+task default: :spec
 

--- a/lib/rack/deflatermaus.rb
+++ b/lib/rack/deflatermaus.rb
@@ -1,16 +1,18 @@
-require "rack/deflatermaus/version"
+require "rack/deflater"
+
 require "rack/deflatermaus/player"
+require "rack/deflatermaus/version"
 
 module Rack
   class Deflatermaus
     def initialize(app)
-      @app = app
+      @deflater = Deflater.new(app)
     end
 
     def call(env)
       Player.new.play
 
-      @app.call(env)
+      @deflater.call(env)
     end
   end
 end

--- a/rack-deflatermaus.gemspec
+++ b/rack-deflatermaus.gemspec
@@ -1,7 +1,8 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'rack/deflatermaus/version'
+
+require "rack/deflatermaus/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "rack-deflatermaus"
@@ -18,7 +19,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "audite", "~> 0.4.0"
+  spec.add_dependency "rack"
 
   spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.1.0"
 end

--- a/spec/rack/deflatermaus_spec.rb
+++ b/spec/rack/deflatermaus_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe Rack::Deflatermaus do
+  it "plays some music" do
+    player = stub_player
+
+    get "/"
+
+    expect(player).to have_received(:play)
+  end
+
+  it "compresses the response" do
+    stub_player
+
+    get "/", "", "HTTP_ACCEPT_ENCODING" => "gzip"
+
+    expect(last_response.headers["Content-Encoding"]).to eq "gzip"
+    expect(last_response.headers["Vary"]).to eq "Accept-Encoding"
+    expect(gunzip(last_response.body)).to eq "hello from Rack"
+  end
+
+  def stub_player
+    player = double("player", play: nil)
+    allow(Rack::Deflatermaus::Player).to receive(:new).and_return(player)
+    player
+  end
+
+  def gunzip(string)
+    Zlib::GzipReader.new(StringIO.new(string)).read
+  end
+
+  def app
+    Rack::Builder.new do
+      use Rack::Deflatermaus
+
+      run lambda { |env| [200, env, ["hello from Rack"]] }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,17 @@
+$LOAD_PATH << File.join(File.dirname(__FILE__), "..", "lib")
+
+require "rack"
+require "rack/deflatermaus"
+
+require "rspec"
+require "rack/test"
+
+Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
Also, now there are tests.

Because _that_ was what stopped people from using this: lack of tests.
